### PR TITLE
Fix helper tool swap tests: change ssh to https url

### DIFF
--- a/tests/swap/helper_tool.py
+++ b/tests/swap/helper_tool.py
@@ -59,11 +59,6 @@ def run_cmd(cmd: str,
 
     return ret.stdout.strip()
 
-def ensure_https_git():
-    # Force HTTPS for all GitHub SSH URLs (incl. submodules)
-    run_cmd('git config --global url."https://github.com/".insteadOf git@github.com:')
-    run_cmd('git config --global url."https://github.com/".insteadOf ssh://git@github.com/')
-
 def submodule_update_https(cwd: Path):
     run_cmd("git submodule sync --recursive", cwd=cwd)
     cmd = (
@@ -77,8 +72,6 @@ def clone_or_pull(repo_url: str, clone_dir: str):
     # Only needed when cloning / pulling, not when building.
     # By putting the import here we allow the script to be imported inside the docker image
     from git import Repo
-
-    ensure_https_git()
 
     git_dir = os.path.join(clone_dir, ".git")
     if not os.path.exists(git_dir):


### PR DESCRIPTION
# Checklist
<!-- Put an `x` in each box when you have completed the items. -->
- [ ] App update process has been followed <!-- See comment below -->
- [ ] Target branch is `develop` <!-- unless you have a very good reason -->
- [ ] Application version has been bumped <!-- required if your changes are to be deployed -->

<!-- Make sure you followed the process described in https://developers.ledger.com/docs/device-app/deliver/maintenance before opening your Pull Request.
Don't hesitate to contact us directly on Discord if you have any questions ! https://developers.ledger.com/discord -->

Change repository URLs from SSH to HTTPS for swap test dependencies

Swap tests were failing in Docker containers because SSH client and keys
are not configured by default. Using HTTPS works out of the box without
any additional setup, making it ideal for ephemeral Docker containers
that are removed after each run.

Changed URLs in helper_tool.py:
- git@github.com → https://github.com for app-exchange and app-ethereum

Advantages: zero configuration overhead, simpler setup, no SSH key management
Potential drawback: private repos would require auth tokens (same as SSH)

